### PR TITLE
Update addon listing to new url

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@
 <sub>that's it. you fricking dummy.</sub>
 
 # ADD-ONS
-- [Team Colored X hitmaker](https://gamebanana.com/mods/431361)
+- [Team Colored X hitmaker](https://gamebanana.com/mods/460476)
 
 # LINKS
 - [DISCORD](https://discord.gg/9QzHkQx)


### PR DESCRIPTION
The old URL leads to a listing that says it's been replaced and point to this new url. 