### PR TITLE
fixed medic shield overlapping in mvm

### DIFF
--- a/resource/ui/huditemeffectmeter_cleaver.res
+++ b/resource/ui/huditemeffectmeter_cleaver.res
@@ -3,6 +3,6 @@
 {
     HudItemEffectMeter
     {
-        "ypos"          "c103"  [$WIN32]
+        "ypos"          "c81"  [$WIN32]
     }
 }

--- a/resource/ui/huditemeffectmeter_scout.res
+++ b/resource/ui/huditemeffectmeter_scout.res
@@ -3,6 +3,6 @@
 {
     HudItemEffectMeter
     {
-        "ypos"          "c103"  [$WIN32]
+        "ypos"          "c81"  [$WIN32]
     }
 }

--- a/resource/ui/huditemeffectmeter_sodapopper.res
+++ b/resource/ui/huditemeffectmeter_sodapopper.res
@@ -1,83 +1,8 @@
+#base "huditemeffectmeter.res"
 "Resource/UI/HudItemEffectMeter_SodaPopper.res"
 {
     HudItemEffectMeter
     {
-        "fieldName"     "HudItemEffectMeter"
-        "visible"       "1"
-        "enabled"       "1"
-        "xpos"          "c-30"  [$WIN32]
-        "ypos"          "c80"   [$WIN32]
-        "ypos_minmode"  "c101"
-        "wide"          "140"
-        "tall"          "30"
-        "MeterFG"       "White"
-        "MeterBG"       "Gray"
-    }
-    "ItemEffectMeterBG"
-    {
-        "ControlName"   "CTFImagePanel"
-        "fieldName"     "ItemEffectMeterBG"
-        "xpos"          "2"
-        "ypos"          "4"
-        "zpos"          "-1"
-        "wide"          "60"
-        "tall"          "22"
-        "autoResize"        "0"
-        "pinCorner"     "0"
-        "visible"       "1"
-        "visible_minmode"   "0"
-        "enabled"       "1"
-        "image"         "../hud/color_panel_brown"
-        "scaleImage"        "1"
-        "teambg_1"      "../hud/color_panel_brown"
-        "teambg_2"      "../hud/color_panel_red"
-        "teambg_2_lodef"    "../hud/color_panel_red"
-        "teambg_3"      "../hud/color_panel_blu"
-        "teambg_3_lodef"    "../hud/color_panel_blu"
-
-        "src_corner_height"     "23"                // pixels inside the image
-        "src_corner_width"      "23"
-
-        "draw_corner_width"     "5"             // screen size of the corners ( and sides ), proportional
-        "draw_corner_height"    "5"
-    }
-    "ItemEffectMeterLabel"
-    {
-        "ControlName"           "CExLabel"
-        "fieldName"             "ItemEffectMeterLabel"
-        "xpos"                  "2"
-        "ypos"                  "5"
-        "ypos_minmode"          "-3"
-        "zpos"                  "2"
-        "wide"                  "60"
-        "tall"                  "30"
-        "autoResize"            "1"
-        "pinCorner"             "2"
-        "visible"               "1"
-        "enabled"               "1"
-        "tabPosition"           "0"
-        "labelText"             "#TF_ENERGYDRINK"
-        "textAlignment"         "center"
-        "dulltext"              "0"
-        "brighttext"            "0"
-        "fgcolor_override"      "Black"
-    }
-    "ItemEffectMeter"
-    {
-		"ControlName"			"ContinuousProgressBar"
-		"fieldName"				"ItemEffectMeter"
-		"font"					"Default"
-		"xpos"					"7"
-		"ypos"					"9"
-		"zpos"					"2"
-		"wide"					"50"
-		"tall"					"6"
-		"autoResize"			"0"
-		"pinCorner"				"0"
-		"visible"				"1"
-		"enabled"				"1"
-		"textAlignment"			"Left"
-		"dulltext"				"0"
-		"brighttext"			"0"
+        "ypos"          "c102"   [$WIN32]
     }
 }


### PR DESCRIPTION
closes #50, fix suggested by @Quantum-Apple

this also optimizes `huditemeffectmeter_sodapopper.res` to also use `#base` like other hud files