### PR TITLE
Item Meter Consistency Fixes + Canteen Customization

### DIFF
--- a/#customizations/Canteen Location/Left (Default)/resource/ui/huditemeffectmeter_powerupbottle.res
+++ b/#customizations/Canteen Location/Left (Default)/resource/ui/huditemeffectmeter_powerupbottle.res
@@ -1,0 +1,145 @@
+#base "huditemeffectmeter.res"
+"Resource/UI/HudItemEffectMeter_PowerupBottles.res"
+{
+    HudItemEffectMeter
+    {
+        "fieldName"     "HudItemEffectMeter"
+        "visible"       "1"
+        "enabled"       "1"
+        "xpos"          "c-300"   [$WIN32]
+        "ypos"          "r75"  [$WIN32]
+        "wide"          "100"
+        "tall"          "60"
+        "MeterFG"       "White"
+        "MeterBG"       "Gray"
+    }
+
+    "ItemEffectMeterBG"
+    {
+        "ControlName"   "CTFImagePanel"
+        "fieldName"     "ItemEffectMeterBG"
+        "xpos"          "2"
+        "ypos"          "4"
+        "zpos"          "-1"
+        "wide"          "70"
+        "tall"          "35"
+        "autoResize"        "0"
+        "pinCorner"     "0"
+        "visible"       "1"
+        "enabled"       "1"
+        "image"         "../hud/color_panel_brown"
+        "scaleImage"        "1"
+        "teambg_1"      "../hud/color_panel_brown"
+        "teambg_2"      "../hud/color_panel_red"
+        "teambg_2_lodef"    "../hud/color_panel_red"
+        "teambg_3"      "../hud/color_panel_blu"
+        "teambg_3_lodef"    "../hud/color_panel_blu"
+
+        "src_corner_height"     "23"                // pixels inside the image
+        "src_corner_width"      "23"
+
+        "draw_corner_width"     "5"             // screen size of the corners ( and sides ), proportional
+        "draw_corner_height"    "5"
+    }
+
+    "ItemEffectIcon"
+    {
+        "ControlName"   "CTFImagePanel"
+        "fieldName"     "ItemEffectIcon"
+        "xpos"          "12"
+        "ypos"          "8"
+        "zpos"          "1"
+        "wide"          "27"
+        "wide_minmode"  "20"
+        "tall"          "27"
+        "tall_minmode"  "20"
+        "visible"       "1"
+        "enabled"       "1"
+        "image"         "../hud/ico_powerup_critboost_red"
+        "scaleImage"    "1"
+    }
+
+    "ItemEffectMeterLabel"
+    {
+        "ControlName"           "CExLabel"
+        "fieldName"             "ItemEffectMeterLabel"
+        "xpos"                  "12"
+        "ypos"                  "32"
+        "zpos"                  "2"
+        "wide"                  "56"
+        "tall"                  "25"
+        "autoResize"            "1"
+        "pinCorner"             "2"
+        "visible"               "0"
+        "enabled"               "1"
+        "tabPosition"           "0"
+        "labelText"             "#TF_Ball"
+        "textAlignment"         "north"
+        "centerwrap"            "1"
+        "dulltext"              "0"
+        "brighttext"            "0"
+        "font"                  "TFFontSmall"
+    }
+
+    "ItemEffectMeter"
+    {
+        "ControlName"           "ContinuousProgressBar"
+        "fieldName"             "ItemEffectMeter"
+        "font"                  "Default"
+        "xpos"                  "25"
+        "ypos"                  "23"
+        "zpos"                  "2"
+        "wide"                  "40"
+        "tall"                  "6"
+        "autoResize"            "0"
+        "pinCorner"             "0"
+        "visible"               "0"
+        "enabled"               "0"
+        "textAlignment"         "Left"
+        "dulltext"              "0"
+        "brighttext"            "0"
+    }
+
+    "ItemEffectMeterCount"
+    {
+        "ControlName"           "CExLabel"
+        "fieldName"             "ItemEffectMeterCount"
+        "xpos"                  "24"
+        "ypos"                  "11"
+        "zpos"                  "2"
+        "wide"                  "40"
+        "tall"                  "20"
+        "pinCorner"             "2"
+        "visible"               "1"
+        "enabled"               "1"
+        "tabPosition"           "0"
+        "labelText"             "%progresscount%"
+        "textAlignment"         "north"
+        "dulltext"              "0"
+        "brighttext"            "0"
+        "font"                  "HudFontMedium"
+    }
+
+    "ItemEffectMeterCountShadow"
+    {
+        "ControlName"   "CExLabel"
+        "fieldName"     "ItemEffectMeterCountShadow"
+        "xpos"          "29"
+        "ypos"          "14"
+        "zpos"          "2"
+        "wide"          "35"
+        "tall"          "20"
+        "tall_lodef"    "28"
+        "autoResize"    "1"
+        "pinCorner"     "2"
+        "visible"       "1"
+        "enabled"       "1"
+        "tabPosition"   "0"
+        "labelText"     "%progresscount%"
+        "textAlignment" "center"
+        "dulltext"      "0"
+        "brighttext"    "0"
+        "font"          "HudFontMedium"
+        "fgcolor_override"  "TransparentBlack"
+    }
+}

--- a/#customizations/Canteen Location/Right/resource/ui/huditemeffectmeter_powerupbottle.res
+++ b/#customizations/Canteen Location/Right/resource/ui/huditemeffectmeter_powerupbottle.res
@@ -1,0 +1,145 @@
+#base "huditemeffectmeter.res"
+"Resource/UI/HudItemEffectMeter_PowerupBottles.res"
+{
+    HudItemEffectMeter
+    {
+        "fieldName"     "HudItemEffectMeter"
+        "visible"       "1"
+        "enabled"       "1"
+        "xpos"          "c200"   [$WIN32]
+        "ypos"          "r132"  [$WIN32]
+        "wide"          "100"
+        "tall"          "60"
+        "MeterFG"       "White"
+        "MeterBG"       "Gray"
+    }
+
+    "ItemEffectMeterBG"
+    {
+        "ControlName"   "CTFImagePanel"
+        "fieldName"     "ItemEffectMeterBG"
+        "xpos"          "2"
+        "ypos"          "4"
+        "zpos"          "-1"
+        "wide"          "70"
+        "tall"          "35"
+        "autoResize"        "0"
+        "pinCorner"     "0"
+        "visible"       "1"
+        "enabled"       "1"
+        "image"         "../hud/color_panel_brown"
+        "scaleImage"        "1"
+        "teambg_1"      "../hud/color_panel_brown"
+        "teambg_2"      "../hud/color_panel_red"
+        "teambg_2_lodef"    "../hud/color_panel_red"
+        "teambg_3"      "../hud/color_panel_blu"
+        "teambg_3_lodef"    "../hud/color_panel_blu"
+
+        "src_corner_height"     "23"                // pixels inside the image
+        "src_corner_width"      "23"
+
+        "draw_corner_width"     "5"             // screen size of the corners ( and sides ), proportional
+        "draw_corner_height"    "5"
+    }
+
+    "ItemEffectIcon"
+    {
+        "ControlName"   "CTFImagePanel"
+        "fieldName"     "ItemEffectIcon"
+        "xpos"          "12"
+        "ypos"          "8"
+        "zpos"          "1"
+        "wide"          "27"
+        "wide_minmode"  "20"
+        "tall"          "27"
+        "tall_minmode"  "20"
+        "visible"       "1"
+        "enabled"       "1"
+        "image"         "../hud/ico_powerup_critboost_red"
+        "scaleImage"    "1"
+    }
+
+    "ItemEffectMeterLabel"
+    {
+        "ControlName"           "CExLabel"
+        "fieldName"             "ItemEffectMeterLabel"
+        "xpos"                  "12"
+        "ypos"                  "32"
+        "zpos"                  "2"
+        "wide"                  "56"
+        "tall"                  "25"
+        "autoResize"            "1"
+        "pinCorner"             "2"
+        "visible"               "0"
+        "enabled"               "1"
+        "tabPosition"           "0"
+        "labelText"             "#TF_Ball"
+        "textAlignment"         "north"
+        "centerwrap"            "1"
+        "dulltext"              "0"
+        "brighttext"            "0"
+        "font"                  "TFFontSmall"
+    }
+
+    "ItemEffectMeter"
+    {
+        "ControlName"           "ContinuousProgressBar"
+        "fieldName"             "ItemEffectMeter"
+        "font"                  "Default"
+        "xpos"                  "25"
+        "ypos"                  "23"
+        "zpos"                  "2"
+        "wide"                  "40"
+        "tall"                  "6"
+        "autoResize"            "0"
+        "pinCorner"             "0"
+        "visible"               "0"
+        "enabled"               "0"
+        "textAlignment"         "Left"
+        "dulltext"              "0"
+        "brighttext"            "0"
+    }
+
+    "ItemEffectMeterCount"
+    {
+        "ControlName"           "CExLabel"
+        "fieldName"             "ItemEffectMeterCount"
+        "xpos"                  "24"
+        "ypos"                  "11"
+        "zpos"                  "2"
+        "wide"                  "40"
+        "tall"                  "20"
+        "pinCorner"             "2"
+        "visible"               "1"
+        "enabled"               "1"
+        "tabPosition"           "0"
+        "labelText"             "%progresscount%"
+        "textAlignment"         "north"
+        "dulltext"              "0"
+        "brighttext"            "0"
+        "font"                  "HudFontMedium"
+    }
+
+    "ItemEffectMeterCountShadow"
+    {
+        "ControlName"   "CExLabel"
+        "fieldName"     "ItemEffectMeterCountShadow"
+        "xpos"          "29"
+        "ypos"          "14"
+        "zpos"          "2"
+        "wide"          "35"
+        "tall"          "20"
+        "tall_lodef"    "28"
+        "autoResize"    "1"
+        "pinCorner"     "2"
+        "visible"       "1"
+        "enabled"       "1"
+        "tabPosition"   "0"
+        "labelText"     "%progresscount%"
+        "textAlignment" "center"
+        "dulltext"      "0"
+        "brighttext"    "0"
+        "font"          "HudFontMedium"
+        "fgcolor_override"  "TransparentBlack"
+    }
+}

--- a/#customizations/Health&Ammo Positions/Centered (Default)/scripts/hudlayout.res
+++ b/#customizations/Health&Ammo Positions/Centered (Default)/scripts/hudlayout.res
@@ -916,7 +916,7 @@
 		"enabled"			"1"
 		"xpos"				"c-44"
 		"xpos_minbad"		"r110"
-		"ypos"				"c75"
+		"ypos"				"c74"
 		"ypos_minbad"		"r30"
 		"wide"				"100"
 		"tall"				"500"

--- a/#customizations/Health&Ammo Positions/Centered (Default)/scripts/hudlayout.res
+++ b/#customizations/Health&Ammo Positions/Centered (Default)/scripts/hudlayout.res
@@ -189,7 +189,7 @@
 	{
 		"fieldName"					"CHudAccountPanel"
 		"xpos"						"c-38"
-		"ypos"						"c66"
+		"ypos"						"c68"
 		"ypos_minbad"				"r134"
 		"zpos"						"1"
 		"wide"						"116"

--- a/#customizations/Health&Ammo Positions/TF2 Style (Corners)/scripts/hudlayout.res
+++ b/#customizations/Health&Ammo Positions/TF2 Style (Corners)/scripts/hudlayout.res
@@ -916,7 +916,7 @@
 		"enabled"			"1"
 		"xpos"				"c-44"
 		"xpos_minbad"		"r110"
-		"ypos"				"c75"
+		"ypos"				"c74"
 		"ypos_minbad"		"r30"
 		"wide"				"100"
 		"tall"				"500"

--- a/#customizations/Health&Ammo Positions/TF2 Style (Corners)/scripts/hudlayout.res
+++ b/#customizations/Health&Ammo Positions/TF2 Style (Corners)/scripts/hudlayout.res
@@ -189,7 +189,7 @@
 	{
 		"fieldName"					"CHudAccountPanel"
 		"xpos"						"c-38"
-		"ypos"						"c66"
+		"ypos"						"c68"
 		"ypos_minbad"				"r134"
 		"zpos"						"1"
 		"wide"						"116"

--- a/resource/ui/huditemeffectmeter_cleaver.res
+++ b/resource/ui/huditemeffectmeter_cleaver.res
@@ -3,6 +3,6 @@
 {
     HudItemEffectMeter
     {
-        "ypos"          "c81"  [$WIN32]
+        "ypos"          "c79"  [$WIN32]
     }
 }

--- a/resource/ui/huditemeffectmeter_engineer.res
+++ b/resource/ui/huditemeffectmeter_engineer.res
@@ -13,6 +13,5 @@
         "scaleImage"    "1"
         "teambg_2"      "replay/thumbnails/ico_crit"
         "teambg_3"      "replay/thumbnails/ico_crit_blu"
-
     }
 }

--- a/resource/ui/huditemeffectmeter_pomson.res
+++ b/resource/ui/huditemeffectmeter_pomson.res
@@ -1,80 +1,21 @@
+#base "huditemeffectmeter.res"
 "Resource/UI/HudItemEffectMeter_Pomson.res"
 {
     HudItemEffectMeter
     {
-        "fieldName"     "HudItemEffectMeter"
-        "visible"       "1"
-        "enabled"       "1"
         "xpos"          "c-70"  [$WIN32]
-        "ypos"          "c129"  [$WIN32]
-        "ypos_minmode"  "c101"
-        "wide"          "140"
-        "tall"          "300"
-        "MeterFG"       "White"
-        "MeterBG"       "Gray"
+        "ypos"          "c131"  [$WIN32]
     }
     "ItemEffectMeterBG"
     {
-		"ControlName"	"CTFImagePanel"
-		"fieldName"		"AccountBG"
 		"xpos"			"37"
-		"ypos"			"0"
-		"zpos"			"0"
 		"wide"			"69"
 		"tall"			"25"
-		"visible"		"1"
-		"enabled"		"1"
-		"image"			"../hud/misc_ammo_area_blue"
-		"scaleImage"	"1"	
-		"teambg_2"		"../hud/color_panel_red"
-		"teambg_2_lodef"	"../hud/misc_ammo_area_red_lodef"
-		"teambg_3"		"../hud/color_panel_blu"
-		"teambg_3_lodef"	"../hud/misc_ammo_area_blue_lodef"
-		
-		"src_corner_height"		"23"				// pixels inside the image
-		"src_corner_width"		"23"
-			
-		"draw_corner_width"		"5"				// screen size of the corners ( and sides ), proportional
-		"draw_corner_height" 	"5"	    
     }
-    "ItemEffectMeterLabel"
-    {
-        "ControlName"           "CExLabel"
-        "fieldName"             "ItemEffectMeterLabel"
-        "xpos"                  "-3"
-        "ypos"                  "3"
-        "ypos_minmode"          "-3"
-        "zpos"                  "2"
-        "wide"                  "150"
-        "tall"                  "30"
-        "autoResize"            "1"
-        "pinCorner"             "2"
-        "visible"               "1"
-        "enabled"               "1"
-        "tabPosition"           "0"
-        "labelText"             "#TF_ENERGYDRINK"
-        "textAlignment"         "center"
-        "dulltext"              "0"
-        "brighttext"            "0"
-        "fgcolor_override"      "TanLight"
-    }   
     "ItemEffectMeter"
-    {   
-        "ControlName"           "ContinuousProgressBar"
-        "fieldName"             "ItemEffectMeter"
-        "font"                  "Default"
+    {
         "xpos"                  "43"
-        "ypos"                  "5"
-        "zpos"                  "2"
         "wide"                  "58"
-        "tall"                  "6"      
-        "tall_minmode"          "7"          
-        "autoResize"            "0"
-        "pinCorner"             "0"
-        "visible"               "1"
-        "enabled"               "1"
-        "textAlignment"         "Left"
-        "dulltext"              "0"
-        "brighttext"            "0"
+        "tall"                  "6"
     }
 }

--- a/resource/ui/huditemeffectmeter_pyro.res
+++ b/resource/ui/huditemeffectmeter_pyro.res
@@ -5,6 +5,6 @@
 	HudItemEffectMeter
 	{
 		"fieldName"		"HudItemEffectMeter"
-		"ypos"          "c102"
+		"ypos"          "c108"
 	}
 }

--- a/resource/ui/huditemeffectmeter_sapper.res
+++ b/resource/ui/huditemeffectmeter_sapper.res
@@ -3,6 +3,6 @@
 {
     HudItemEffectMeter
     {
-        "ypos"  "r181"
+        "ypos"  "c81"
     }
 }

--- a/resource/ui/huditemeffectmeter_scout.res
+++ b/resource/ui/huditemeffectmeter_scout.res
@@ -3,6 +3,6 @@
 {
     HudItemEffectMeter
     {
-        "ypos"          "c81"  [$WIN32]
+        "ypos"          "c79"  [$WIN32]
     }
 }

--- a/resource/ui/huditemeffectmeter_spy.res
+++ b/resource/ui/huditemeffectmeter_spy.res
@@ -4,37 +4,7 @@
 {
     HudItemEffectMeter
     {
-        "ypos"          "c82"  [$WIN32]
-        "MeterFG"       "White"
-        "MeterBG"       "Gray"
-    }
-    "ItemEffectMeterBG"
-    {
-        "ControlName"   "CTFImagePanel"
-        "fieldName"     "ItemEffectMeterBG"
-        "xpos"          "54"
-        "ypos"          "1"
-        "zpos"          "-1"
-        "wide"          "60"
-        "tall"          "24"
-        "autoResize"        "0"
-        "pinCorner"     "0"
-        "visible"       "1"
-        "visible_minmode"   "0"
-        "enabled"       "1"
-        "image"         "../hud/color_panel_brown"
-        "scaleImage"        "1"
-        "teambg_1"      "../hud/color_panel_brown"
-        "teambg_2"      "../hud/color_panel_red"
-        "teambg_2_lodef"    "../hud/color_panel_red"
-        "teambg_3"      "../hud/color_panel_blu"
-        "teambg_3_lodef"    "../hud/color_panel_blu"
-
-        "src_corner_height"     "23"                // pixels inside the image
-        "src_corner_width"      "23"
-
-        "draw_corner_width"     "5"             // screen size of the corners ( and sides ), proportional
-        "draw_corner_height"    "5"
+        "ypos"          "r181"  [$WIN32]
     }
     "CritIcon"
     {

--- a/resource/ui/hudrocketpack.res
+++ b/resource/ui/hudrocketpack.res
@@ -1,45 +1,16 @@
+#base "huditemeffectmeter.res"
 "Resource/UI/HudRocketPack.res"
 {
 	HudItemEffectMeter
     {
-        "fieldName"     "HudItemEffectMeter"
-        "visible"       "1"
-        "enabled"       "1"
-        "xpos"          "c-70"  [$WIN32]
-        "ypos"          "c124"  [$WIN32]
-        "ypos_minmode"  "c123"
-        "wide"          "140"
-        "tall"          "300"
-        "MeterFG"       "White"
-        "MeterBG"       "Gray"
+        "ypos"          "c123"  [$WIN32]
     }
     "ItemEffectMeterBG"
     {
-        "ControlName"   "CTFImagePanel"
-        "fieldName"     "ItemEffectMeterBG"
         "xpos"          "22"
         "ypos"          "4"
-        "zpos"          "-1"
         "wide"          "97"
         "tall"          "22"
-        "autoResize"        "0"
-        "pinCorner"     "0"
-        "visible"       "1"
-        "visible_minmode"       "0"
-        "enabled"       "1"
-        "image"         "../hud/color_panel_brown"
-        "scaleImage"        "1"
-        "teambg_1"      "../hud/color_panel_brown"
-        "teambg_2"      "../hud/color_panel_red"
-        "teambg_2_lodef"    "../hud/color_panel_red"
-        "teambg_3"      "../hud/color_panel_blu"
-        "teambg_3_lodef"    "../hud/color_panel_blu"
-        
-        "src_corner_height"     "23"                // pixels inside the image
-        "src_corner_width"      "23"
-            
-        "draw_corner_width"     "5"             // screen size of the corners ( and sides ), proportional
-        "draw_corner_height"    "5"     
     }
 	"ItemEffectIcon"
 	{
@@ -55,7 +26,7 @@
 		"visible_minmode"	"1"
 		"enabled"			"1"
 		"image"				"../hud/pyro_jetpack_off2"
-		"scaleImage"		"1"	
+		"scaleImage"		"1"
 	}
     "ItemEffectMeterLabel"
     {
@@ -79,7 +50,7 @@
         "fgcolor_override"      "Black"
     }
     "ItemEffectMeter"
-    {   
+    {
         "ControlName"           "ContinuousProgressBar"
         "fieldName"             "ItemEffectMeter"
         "font"                  "Default"
@@ -88,7 +59,7 @@
         "zpos"                  "2"
         "wide"                  "30"
         "tall"                  "12"
-        "tall_minmode"          "7"        
+        "tall_minmode"          "7"
         "autoResize"            "0"
         "pinCorner"             "0"
         "visible"               "1"
@@ -98,7 +69,7 @@
         "brighttext"            "0"
     }
 	"ItemEffectMeter2"
-	{	
+	{
 		"ControlName"	"ContinuousProgressBar"
 		"fieldName"		"ItemEffectMeter2"
 		"font"			"Default"
@@ -107,7 +78,7 @@
 		"zpos"			"2"
 		"wide"			"30"
 		"tall"			"12"
-		"tall_minmode"  "7"        		
+		"tall_minmode"  "7"
 		"autoResize"	"0"
 		"pinCorner"		"0"
 		"visible"		"1"

--- a/resource/ui/hudrocketpack.res
+++ b/resource/ui/hudrocketpack.res
@@ -3,7 +3,7 @@
 {
 	HudItemEffectMeter
     {
-        "ypos"          "c123"  [$WIN32]
+        "ypos"          "c129"  [$WIN32]
     }
     "ItemEffectMeterBG"
     {

--- a/scripts/hudlayout.res
+++ b/scripts/hudlayout.res
@@ -918,7 +918,7 @@
 		"enabled"			"1"
 		"xpos"				"c-44"
 		"xpos_minbad"		"r110"
-		"ypos"				"c75"
+		"ypos"				"c74"
 		"ypos_minbad"		"r30"
 		"wide"				"100"
 		"tall"				"500"

--- a/scripts/hudlayout.res
+++ b/scripts/hudlayout.res
@@ -191,7 +191,7 @@
 	{
 		"fieldName"					"CHudAccountPanel"
 		"xpos"						"c-38"
-		"ypos"						"c66"
+		"ypos"						"c68"
 		"ypos_minbad"				"r134"
 		"zpos"						"1"
 		"wide"						"116"


### PR DESCRIPTION
closes #67
closes #68 

increased pyro thermal thruster height
fixed pomson meter overlap
lowered engineer metal to make more sense between frontier justice crits and metal 
swapped around diamondback crits and sapper meter
fixed demoman stickies/charge and eyelander heads 1px spacing issue
added customization for the location of the powerup canteen in mvm
fixed phlog + manmelter and phlog + thermal thruster meter inconsistency