### PR TITLE
Fix killfeed and chat position for ultrawides

### DIFF
--- a/#customizations/Health&Ammo Positions/Centered (Default)/scripts/hudlayout.res
+++ b/#customizations/Health&Ammo Positions/Centered (Default)/scripts/hudlayout.res
@@ -429,7 +429,7 @@
 		"fieldName"						"HudDeathNotice"
 		"visible"						"1"
 		"enabled"						"1"
-		"xpos"							"r640"
+		"xpos"							"c-210"
 		"ypos"							"18"
 		"wide"							"628"
 		"tall"							"468"

--- a/#customizations/Health&Ammo Positions/TF2 Style (Corners)/scripts/hudlayout.res
+++ b/#customizations/Health&Ammo Positions/TF2 Style (Corners)/scripts/hudlayout.res
@@ -427,7 +427,7 @@
 		"fieldName"						"HudDeathNotice"
 		"visible"						"1"
 		"enabled"						"1"
-		"xpos"							"r640"
+		"xpos"							"c-210"
 		"ypos"							"18"
 		"wide"							"628"
 		"tall"							"468"

--- a/resource/ui/basechat.res
+++ b/resource/ui/basechat.res
@@ -6,7 +6,7 @@
 		"fieldName" 			"HudChat"
 		"visible" 				"1"
 		"enabled" 				"1"
-		"xpos"					"40"
+		"xpos"					"c-410"
 		"ypos"					"r220"
 		"wide"					"220"
 		"tall"					"100"

--- a/scripts/hudlayout.res
+++ b/scripts/hudlayout.res
@@ -417,7 +417,7 @@
 		"fieldName"						"HudDeathNotice"
 		"visible"						"1"
 		"enabled"						"1"
-		"xpos"							"r640"
+		"xpos"							"c-210"
 		"ypos"							"18"
 		"wide"							"628"
 		"tall"							"468"


### PR DESCRIPTION
The killfeed and chat are positioned relative to the edges of the screen. This means that they are positioned pretty far away compared to the normal UI on a 1920x1080 screen:

| 1920x1080 | 3440x1440 | 3440x1440 with 16:9 highlighted |
| -- | -- | -- |
| ![image](https://github.com/Vexcenot/-Middle-Mann/assets/153703497/ff46e41c-dda6-45db-aeec-197690eeb3be) | ![image](https://github.com/Vexcenot/-Middle-Mann/assets/153703497/76b5af74-b021-4788-b3db-417cb7564a5c) | ![image](https://github.com/Vexcenot/-Middle-Mann/assets/153703497/68df0500-f11a-416a-bf50-bc4644782bdb) |

My PR makes them positioned relative to the center of the screen so that they maintain their position towards the middle regardless of the resolution/aspect ratio:

| 1920x1080 | 3440x1440 | 3440x1440 with 16:9 highlighted |
| -- | -- | -- |
| ![image](https://github.com/Vexcenot/-Middle-Mann/assets/153703497/9484c982-c2ae-4e14-8cae-405b79d8f4e9) | ![image](https://github.com/Vexcenot/-Middle-Mann/assets/153703497/91ca9561-abc0-4c4c-819c-b5ad153ebe00) | ![image](https://github.com/Vexcenot/-Middle-Mann/assets/153703497/716a0b93-3655-47f3-9132-711db3ade743) |

I made sure to update each customization that referenced these two files too. 

Note that the values I picked do slightly move them in the normal 1920x1080 view. Happy to edit the `c-` values if you'd prefer it to stay exactly the same.